### PR TITLE
Ajout de la validation des produits et des tests associés

### DIFF
--- a/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/ProductServiceTests.cs
+++ b/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/ProductServiceTests.cs
@@ -1,26 +1,105 @@
-﻿using Xunit;
+﻿using P3AddNewFunctionalityDotNetCore.Models.Services;
+using P3AddNewFunctionalityDotNetCore.Models.ViewModels;
+using P3AddNewFunctionalityDotNetCore.Tests.Stubs;
+
+using Xunit;
+
 
 namespace P3AddNewFunctionalityDotNetCore.Tests
 {
-    public class ProductServiceTests
+
+    public class ProductServiceValidationTests
     {
-        /// <summary>
-        /// Take this test method as a template to write your test method.
-        /// A test method must check if a definite method does its job:
-        /// returns an expected value from a particular set of parameters
-        /// </summary>
-        [Fact]
-        public void ExampleMethod()
+        private readonly ProductService _productService;
+
+        public ProductServiceValidationTests()
         {
-            // Arrange
-
-            // Act
-
-
-            // Assert
-            Assert.Equal(1, 1);
+            _productService = new ProductService(
+                   new CartStub(), 
+                   new ProductRepositoryStub(), 
+                   new OrderRepositoryStub(),   
+                   new StringLocalizerStub()   
+            );
         }
 
-        // TODO write test methods to ensure a correct coverage of all possibilities
+        [Fact]
+        public void CheckProduct_Should_ReturnMissingName_When_NameIsEmpty()
+        {
+            var product = new ProductViewModel { Name = "", Price = "10", Stock = "5" };
+
+            var result = _productService.CheckProduct(product);
+
+            Assert.Contains("MissingName", result);
+        }
+
+        [Fact]
+        public void CheckProduct_Should_ReturnMissingPrice_When_PriceIsEmpty()
+        {
+            var product = new ProductViewModel { Name = "Produit", Price = "", Stock = "5" };
+
+            var result = _productService.CheckProduct(product);
+
+            Assert.Contains("MissingPrice", result);
+        }
+
+        [Fact]
+        public void CheckProduct_Should_ReturnPriceNotGreaterThanZero_When_PriceIsZero()
+        {
+            var product = new ProductViewModel { Name = "Produit", Price = "0", Stock = "5" };
+
+            var result = _productService.CheckProduct(product);
+
+            Assert.Contains("PriceNotGreaterThanZero", result);
+        }
+
+        [Fact]
+        public void CheckProduct_Should_ReturnPriceNotANumber_When_PriceIsNotDecimal()
+        {
+            var product = new ProductViewModel { Name = "Produit", Price = "abc", Stock = "5" };
+
+            var result = _productService.CheckProduct(product);
+
+            Assert.Contains("PriceNotANumber", result);
+        }
+
+        [Fact]
+        public void CheckProduct_Should_ReturnMissingQuantity_When_StockIsEmpty()
+        {
+            var product = new ProductViewModel { Name = "Produit", Price = "10", Stock = "" };
+
+            var result = _productService.CheckProduct(product);
+
+            Assert.Contains("MissingQuantity", result);
+        }
+
+        [Fact]
+        public void CheckProduct_Should_ReturnQuantityNotAnInteger_When_StockIsFloat()
+        {
+            var product = new ProductViewModel { Name = "Produit", Price = "10", Stock = "3.14" };
+
+            var result = _productService.CheckProduct(product);
+
+            Assert.Contains("QuantityNotAnInteger", result);
+        }
+
+        [Fact]
+        public void CheckProduct_Should_ReturnQuantityNotGreaterThanZero_When_StockIsZero()
+        {
+            var product = new ProductViewModel { Name = "Produit", Price = "10", Stock = "0" };
+
+            var result = _productService.CheckProduct(product);
+
+            Assert.Contains("QuantityNotGreaterThanZero", result);
+        }
+
+        [Fact]
+        public void CheckProduct_Should_ReturnNoError_When_ValidProduct()
+        {
+            var product = new ProductViewModel { Name = "Produit valide", Price = "10.99", Stock = "7" };
+
+            var result = _productService.CheckProduct(product);
+
+            Assert.Empty(result);
+        }
     }
 }

--- a/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/Stubs/CartStub.cs
+++ b/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/Stubs/CartStub.cs
@@ -1,0 +1,33 @@
+﻿using P3AddNewFunctionalityDotNetCore.Models;
+using P3AddNewFunctionalityDotNetCore.Models.Entities;
+
+namespace P3AddNewFunctionalityDotNetCore.Tests.Stubs
+{
+    internal class CartStub : ICart
+    {
+        public void AddItem(Product product, int quantity)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public double GetAverageValue()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public double GetTotalValue()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void RemoveLine(Product product)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/Stubs/OrderRepositoryStub.cs
+++ b/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/Stubs/OrderRepositoryStub.cs
@@ -1,0 +1,25 @@
+﻿using P3AddNewFunctionalityDotNetCore.Models.Entities;
+using P3AddNewFunctionalityDotNetCore.Models.Repositories;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace P3AddNewFunctionalityDotNetCore.Tests.Stubs
+{
+    internal class OrderRepositoryStub : IOrderRepository
+    {
+        public Task<Order> GetOrder(int? id)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<IList<Order>> GetOrders()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Save(Order order)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/Stubs/ProductRepositoryStub.cs
+++ b/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/Stubs/ProductRepositoryStub.cs
@@ -1,0 +1,40 @@
+﻿using P3AddNewFunctionalityDotNetCore.Models.Entities;
+using P3AddNewFunctionalityDotNetCore.Models.Repositories;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace P3AddNewFunctionalityDotNetCore.Tests.Stubs
+{
+    internal class ProductRepositoryStub : IProductRepository
+    {
+        public void DeleteProduct(int id)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IEnumerable<Product> GetAllProducts()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<Product> GetProduct(int id)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<IList<Product>> GetProduct()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void SaveProduct(Product product)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void UpdateProductStocks(int productId, int quantityToRemove)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/Stubs/StringLocalizerStub.cs
+++ b/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore.Tests/Stubs/StringLocalizerStub.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Localization;
+using P3AddNewFunctionalityDotNetCore.Models.Services;
+using System.Collections.Generic;
+
+namespace P3AddNewFunctionalityDotNetCore.Tests.Stubs
+{
+    internal class StringLocalizerStub : IStringLocalizer<ProductService>
+    {
+        public LocalizedString this[string name] => throw new System.NotImplementedException();
+
+        public LocalizedString this[string name, params object[] arguments] => throw new System.NotImplementedException();
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore/Models/Services/ProductService.cs
+++ b/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore/Models/Services/ProductService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -90,47 +91,14 @@ namespace P3AddNewFunctionalityDotNetCore.Models.Services
             }
         }
 
-        // TODO this is an example method, remove it and perform model validation using data annotations
-        //public List<string> CheckProductModelErrors(ProductViewModel product)
-        //{
-        //    List<string> modelErrors = new List<string>();
-        //    if (product.Name == null || string.IsNullOrWhiteSpace(product.Name))
-        //    {
-        //        modelErrors.Add(_localizer["MissingName"]);
-        //    }
+        public List<string> CheckProduct(ProductViewModel product)
+        {
+            var results = new List<ValidationResult>();
+            var context = new ValidationContext(product);
+            var isValid = Validator.TryValidateObject(product, context, results, true);
 
-        //    if (product.Price == null || string.IsNullOrWhiteSpace(product.Price))
-        //    {
-        //        modelErrors.Add(_localizer["MissingPrice"]);
-        //    }
-
-        //    if (!Double.TryParse(product.Price, out double pc))
-        //    {
-        //        modelErrors.Add(_localizer["PriceNotANumber"]);
-        //    }
-        //    else
-        //    {
-        //        if (pc <= 0)
-        //            modelErrors.Add(_localizer["PriceNotGreaterThanZero"]);
-        //    }
-
-        //    if (product.Stock == null || string.IsNullOrWhiteSpace(product.Stock))
-        //    {
-        //        modelErrors.Add(_localizer["MissingQuantity"]);
-        //    }
-
-        //    if (!int.TryParse(product.Stock, out int qt))
-        //    {
-        //        modelErrors.Add(_localizer["StockNotAnInteger"]);
-        //    }
-        //    else
-        //    {
-        //        if (qt <= 0)
-        //            modelErrors.Add(_localizer["StockNotGreaterThanZero"]);
-        //    }
-
-        //    return modelErrors;
-        //}
+            return results.Select(r => r.ErrorMessage).ToList();
+        }
 
         public void SaveProduct(ProductViewModel product)
         {

--- a/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore/Models/ViewModels/ProductViewModel.cs
+++ b/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore/Models/ViewModels/ProductViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.ComponentModel.DataAnnotations;
+using System.Configuration;
 
 
 
@@ -18,11 +19,13 @@ namespace P3AddNewFunctionalityDotNetCore.Models.ViewModels
         public string Details { get; set; }
 
         [Required(ErrorMessage = "MissingPrice")]
+        [RegularExpression(@"^\d+(\.\d{1,2})?$", ErrorMessage = "PriceNotANumber")]
         [Range(0.01, double.MaxValue, ErrorMessage = "PriceNotGreaterThanZero")]
         public string Price { get; set; } 
 
         [Required(ErrorMessage = "MissingQuantity")]
-        [Range(1, int.MaxValue, ErrorMessage = "StockNotGreaterThanZero")]
+        [RegularExpression(@"^\d+$", ErrorMessage = "QuantityNotAnInteger")]
+        [Range(1, int.MaxValue, ErrorMessage = "QuantityNotGreaterThanZero")]
         public string Stock { get; set; }
     }
 }


### PR DESCRIPTION
Création de la classe `ProductServiceValidationTests` pour tester la validation des produits. Ajout de la méthode `CheckProduct` dans `ProductService.cs` pour valider les modèles de produits avec des annotations de données. Mise à jour des propriétés `Price` et `Stock` dans `ProductViewModel.cs` avec des annotations de validation. Introduction de nouveaux fichiers de stub pour simuler les dépendances dans les tests, facilitant ainsi les tests unitaires du `ProductService`.