### PR TITLE
FIX de la méthode CheckProductModelErrors

### DIFF
--- a/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore/Models/Services/ProductService.cs
+++ b/DotNetEnglishP3-master/P3AddNewFunctionalityDotNetCore/Models/Services/ProductService.cs
@@ -128,5 +128,10 @@ namespace P3AddNewFunctionalityDotNetCore.Models.Services
 
             _productRepository.DeleteProduct(id);
         }
+
+        public List<string> CheckProductModelErrors(ProductViewModel product)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Implémentation d'une nouvelle méthode `CheckProductModelErrors` dans la classe `ProductService`. Cette méthode accepte un `ProductViewModel` et lève une exception `NotImplementedException`, signalant que la fonctionnalité n'est pas encore développée.